### PR TITLE
Change page title to be more descriptive

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
       ga('send', 'pageview');
 
     </script>
-    <title>FTDS</title>
+    <title>Flow-Typed Definition Search</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Wow! Thank you for this project, this helped me update various flow-typed definitions. I've always wanted something like this to exist as finding type definition ranges within the flow-typed repository can be a pain.

I propose changing the title from FTDS to the non-abbreviated name. This is to make bookmarking the page easier and hopefully for search engines to be able to show this tool for what it does :smile:

The way I found myself here was by looking at your contributions in the flow-typed repository, especially considering the CLI. Thank you for your work there! I'm very pleased to find that people like you from flow community are able to help with the `flow-typed` CLI to make it better :)